### PR TITLE
Fix CSRF error when form submitted more than once

### DIFF
--- a/SimpleContactForm.module
+++ b/SimpleContactForm.module
@@ -385,11 +385,10 @@ EOD;
     // validate form and send mail
     if (!empty($this->input->post->submitted)) {
       $this->sendMail();
-    } else {
-      // set CSRF token name and value
-      $this->input->tokenName  = $this->session->CSRF->getTokenName();
-      $this->input->tokenValue = $this->session->CSRF->getTokenValue();
     }
+    // set CSRF token name and value
+    $this->input->tokenName  = $this->session->CSRF->getTokenName();
+    $this->input->tokenValue = $this->session->CSRF->getTokenValue();
 
     $contactPage = new Page();
     $contactPage->set('template', $this->decamelize(self::CLASS_NAME));


### PR DESCRIPTION
The token name and the token value are only loaded when the form isn't submitted. Therefore there is an error when I submit the form with an empty field, and then submit it again after correcting the field.
